### PR TITLE
fix nondeterministic bugs

### DIFF
--- a/dreamplace/ops/pin2pin_attraction/src/functional_cuda.h
+++ b/dreamplace/ops/pin2pin_attraction/src/functional_cuda.h
@@ -7,6 +7,33 @@
 
 DREAMPLACE_BEGIN_NAMESPACE
 
+// Optimized atomic add for signed long long integers using fixed-point arithmetic
+template <typename T>
+__device__ long long int atomicAddSigned(long long int* address, T value, long long int scale_factor) {
+    // Scale the input value to fixed-point representation
+    long long int scaled_value = (long long int)(value * scale_factor);
+
+    // For newer GPU architectures, try to use native atomicAdd if available
+    #if __CUDA_ARCH__ >= 600
+    // Use native atomicAdd for long long (supported on sm_60+)
+    return atomicAdd((unsigned long long int*)address, (unsigned long long int)scaled_value);
+    #else
+    // Fallback to atomicCAS for older architectures
+    long long int old_val, new_val, assumed;
+    old_val = *address;
+    do {
+        assumed = old_val;
+        new_val = assumed + scaled_value;
+        old_val = atomicCAS((unsigned long long int*)address,
+                           (unsigned long long int)assumed,
+                           (unsigned long long int)new_val);
+    } while (assumed != old_val);
+    return old_val;
+    #endif
+}
+
+
+
 template <typename T>
 __global__ void pin2pinAttractionCudaForward(
   const T *pin_pos_x, const T *pin_pos_y,
@@ -21,9 +48,9 @@ __global__ void pin2pinAttractionCudaForward(
     if (idx < num_pairs) {
         int pin_id1 = pairs[2 * idx];
         int pin_id2 = pairs[2 * idx + 1];
-        float dx = pin_pos_x[pin_id1] - pin_pos_x[pin_id2];
-        float dy = pin_pos_y[pin_id1] - pin_pos_y[pin_id2];
-        float distance = weights[idx] * (dx * dx + dy * dy);
+        T dx = pin_pos_x[pin_id1] - pin_pos_x[pin_id2];
+        T dy = pin_pos_y[pin_id1] - pin_pos_y[pin_id2];
+        T distance = weights[idx] * (dx * dx + dy * dy);
         atomicAdd(total_distance, distance); // Atomic addition to accumulate the total distance
     }
 }
@@ -42,15 +69,69 @@ __global__ void pin2pinAttractionCudaBackward(
     if (idx < num_pairs) {
         int pin_id1 = pairs[2 * idx];
         int pin_id2 = pairs[2 * idx + 1];
-        float dx = pin_pos_x[pin_id1] - pin_pos_x[pin_id2];
-        float dy = pin_pos_y[pin_id1] - pin_pos_y[pin_id2];
-        float grad_x = 2 * (*grad_tensor) * weights[idx] * dx; // Assuming grad_input is a scalar
-        float grad_y = 2 * (*grad_tensor) * weights[idx] * dy;
+        T dx = pin_pos_x[pin_id1] - pin_pos_x[pin_id2];
+        T dy = pin_pos_y[pin_id1] - pin_pos_y[pin_id2];
+        T grad_x = 2 * (*grad_tensor) * weights[idx] * dx; // Assuming grad_input is a scalar
+        T grad_y = 2 * (*grad_tensor) * weights[idx] * dy;
 
         atomicAdd(&grad_x_tensor[pin_id1], grad_x);
         atomicAdd(&grad_y_tensor[pin_id1], grad_y);
         atomicAdd(&grad_x_tensor[pin_id2], -grad_x);
         atomicAdd(&grad_y_tensor[pin_id2], -grad_y);
+    }
+}
+
+// Deterministic forward kernel using fixed-point arithmetic
+template <typename T>
+__global__ void pin2pinAttractionCudaDeterministicForward(
+  const T *pin_pos_x, const T *pin_pos_y,
+  const int *pairs, const T *weights, int num_pairs,
+  long long int scale_factor,
+  long long int *buf_total_distance
+) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < num_pairs) {
+        int pin_id1 = pairs[2 * idx];
+        int pin_id2 = pairs[2 * idx + 1];
+        T dx = pin_pos_x[pin_id1] - pin_pos_x[pin_id2];
+        T dy = pin_pos_y[pin_id1] - pin_pos_y[pin_id2];
+        T distance = weights[idx] * (dx * dx + dy * dy);
+        // Use custom signed atomic add
+        atomicAddSigned(buf_total_distance, distance, scale_factor);
+    }
+}
+
+// Deterministic backward kernel using fixed-point arithmetic
+template <typename T>
+__global__ void pin2pinAttractionCudaDeterministicBackward(
+  const T *pin_pos_x, const T *pin_pos_y,
+  const int *pairs, const T *weights, int num_pairs,
+  int num_pins, // Add num_pins parameter for bounds checking
+  const T *grad_tensor,
+  long long int scale_factor,
+  long long int *buf_grad_x,
+  long long int *buf_grad_y
+) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < num_pairs) {
+        int pin_id1 = pairs[2 * idx];
+        int pin_id2 = pairs[2 * idx + 1];
+
+        // Bounds checking
+        if (pin_id1 >= num_pins || pin_id2 >= num_pins || pin_id1 < 0 || pin_id2 < 0) {
+            return; // Skip this pair
+        }
+
+        T dx = pin_pos_x[pin_id1] - pin_pos_x[pin_id2];
+        T dy = pin_pos_y[pin_id1] - pin_pos_y[pin_id2];
+        T grad_x = 2 * (*grad_tensor) * weights[idx] * dx;
+        T grad_y = 2 * (*grad_tensor) * weights[idx] * dy;
+
+        // Apply atomic operations using custom signed atomic add
+        atomicAddSigned(&buf_grad_x[pin_id1], grad_x, scale_factor);
+        atomicAddSigned(&buf_grad_y[pin_id1], grad_y, scale_factor);
+        atomicAddSigned(&buf_grad_x[pin_id2], -grad_x, scale_factor);
+        atomicAddSigned(&buf_grad_y[pin_id2], -grad_y, scale_factor);
     }
 }
 

--- a/dreamplace/ops/pin2pin_attraction/src/pin2pin_attraction_cuda_kernel.cu
+++ b/dreamplace/ops/pin2pin_attraction/src/pin2pin_attraction_cuda_kernel.cu
@@ -1,9 +1,15 @@
 #include <cfloat>
+#include <cmath>
 #include "cuda_runtime.h"
-#include "utility/src/utils.cuh"
 #include "pin2pin_attraction/src/functional_cuda.h"
 
 DREAMPLACE_BEGIN_NAMESPACE
+
+// Explicit computation mode enumeration 
+enum ComputationMode {
+    FORWARD_MODE = 0,
+    BACKWARD_MODE = 1
+};
 
 template <typename T>
 int pin2pinAttractionCudaLauncher(
@@ -11,27 +17,91 @@ int pin2pinAttractionCudaLauncher(
   const int *pairs, // Pin pairs (flat array of indices)
   const T *weights, // Weights for each pair, updated to use T
   int num_pairs,
+  int num_pins, // Add actual number of pins parameter
   T *total_distance, // Corrected parameter order and type
   const T *grad_tensor,
-  T *grad_x_tensor, T *grad_y_tensor
+  T *grad_x_tensor, T *grad_y_tensor,
+  bool deterministic_flag,
+  ComputationMode computation_mode // Explicit mode parameter
 ) {
   int thread_count = 64;
   int block_count = (num_pairs + thread_count - 1) / thread_count; // Correct calculation of blocks
   dim3 block_size(thread_count, 1, 1); // Simplified block dimensions
 
-  if (grad_tensor) {
-    pin2pinAttractionCudaBackward<<<block_count, block_size>>>(
-        pin_pos_x, pin_pos_y,
-        pairs, weights, num_pairs, total_distance,
-        grad_tensor, grad_x_tensor, grad_y_tensor
+  if (deterministic_flag && computation_mode == FORWARD_MODE) {
+    
+    int fraction_bits = 32;   // determine optimal fraction bits based on experimental value range
+
+    long long int scale_factor = (1LL << fraction_bits);
+    // Run deterministic version with calculated scaling factor
+    long long int *buf_total_distance;
+    allocateCUDA(buf_total_distance, 1, long long int);
+
+    // Initialize buffer to zero since total_distance starts from zero in each call
+    checkCUDA(cudaMemset(buf_total_distance, 0, sizeof(long long int)));
+
+    pin2pinAttractionCudaDeterministicForward<<<block_count, block_size>>>(
+        pin_pos_x, pin_pos_y, pairs, weights, num_pairs,
+        scale_factor, buf_total_distance
     );
+
+    // Convert back to floating point using standard copyScaleArray
+    copyScaleArray<<<1, 1>>>(total_distance, buf_total_distance, T(1.0 / scale_factor), 1);
+
+    destroyCUDA(buf_total_distance);
+
+  } else if (deterministic_flag && computation_mode == BACKWARD_MODE) {
+    
+
+    int fraction_bits = 32;
+
+    long long int scale_factor = (1LL << fraction_bits);
+
+    // Allocate buffers for deterministic computation
+    long long int *buf_grad_x, *buf_grad_y;
+    allocateCUDA(buf_grad_x, num_pins, long long int);
+    allocateCUDA(buf_grad_y, num_pins, long long int);
+
+    // Initialize buffers to zero to avoid double scaling
+    int grad_thread_count = 256;
+    int grad_block_count = (num_pins + grad_thread_count - 1) / grad_thread_count;
+    checkCUDA(cudaMemset(buf_grad_x, 0, num_pins * sizeof(long long int)));
+    checkCUDA(cudaMemset(buf_grad_y, 0, num_pins * sizeof(long long int)));
+
+    // Run deterministic backward pass with optimal scaling
+    pin2pinAttractionCudaDeterministicBackward<<<block_count, block_size>>>(
+        pin_pos_x, pin_pos_y, pairs, weights, num_pairs, num_pins, grad_tensor,
+        scale_factor, buf_grad_x, buf_grad_y
+    );
+
+    // Convert back to floating point using standard copyScaleArray
+    copyScaleArray<<<grad_block_count, grad_thread_count>>>(
+        grad_x_tensor, buf_grad_x, T(1.0 / scale_factor), num_pins);
+    copyScaleArray<<<grad_block_count, grad_thread_count>>>(
+        grad_y_tensor, buf_grad_y, T(1.0 / scale_factor), num_pins);
+
+    // Clean up temporary buffers
+  
+    destroyCUDA(buf_grad_x);
+    destroyCUDA(buf_grad_y);
+
   } else {
-    pin2pinAttractionCudaForward<<<block_count, block_size>>>(
-        pin_pos_x, pin_pos_y,
-        pairs, weights, num_pairs, total_distance,
-        grad_tensor, grad_x_tensor, grad_y_tensor
-    );
+    // NON-DETERMINISTIC MODE
+    if (computation_mode == BACKWARD_MODE) {
+      pin2pinAttractionCudaBackward<<<block_count, block_size>>>(
+          pin_pos_x, pin_pos_y,
+          pairs, weights, num_pairs, total_distance,
+          grad_tensor, grad_x_tensor, grad_y_tensor
+      );
+    } else { // FORWARD_MODE
+      pin2pinAttractionCudaForward<<<block_count, block_size>>>(
+          pin_pos_x, pin_pos_y,
+          pairs, weights, num_pairs, total_distance,
+          grad_tensor, grad_x_tensor, grad_y_tensor
+      );
+    }
   }
+
   cudaDeviceSynchronize(); // Ensure completion before return
   return 0;
 }
@@ -42,9 +112,12 @@ template int pin2pinAttractionCudaLauncher<T>(              \
     const int *pairs,                                       \
     const T *weights,                                       \
     int num_pairs,                                          \
+    int num_pins,                                           \
     T *total_distance,                                      \
     const T *grad_tensor,                                   \
-    T *grad_x_tensor, T *grad_y_tensor                      \
+    T *grad_x_tensor, T *grad_y_tensor,                     \
+    bool deterministic_flag,                                \
+    ComputationMode computation_mode                        \
 )
 
 REGISTER_KERNEL_LAUNCHER(float);


### PR DESCRIPTION
We fixed the nondeterministic bugs in Efficient-TDP.
The nondeterministic bugs in the original Efficient-TDP are caused by two reasons: 
- Applying atomicAdd operations to floating point numbers in "dreamplace/ops/pin2pin_attraction/src/pin2pin_attraction_cuda_kernel.cu"
- Dynamic path insertion by different threads in "thirdparty/OpenTimer/ot/timer/path.cpp"
